### PR TITLE
Change wording as actual deletion date may be before the given date

### DIFF
--- a/app/views/expire_hosts_mailer/stopped_hosts_notification.html.erb
+++ b/app/views/expire_hosts_mailer/stopped_hosts_notification.html.erb
@@ -1,4 +1,4 @@
-<%= _('The following hosts have been expired in Foreman and will be stopped for now. These hosts will be destroyed on %s.') % l(@delete_date) %>
+<%= _('The following hosts have been expired in Foreman and will be stopped for now. These hosts will be destroyed before %s.') % l(@delete_date) %>
 <% if @authorized_for_expiry_date_change %>
 <%= _('Please change their expiry date and power them on if you want to keep the hosts.') %>
 <% end %>


### PR DESCRIPTION
Every day users will get a new mail warning them that the host will be deleted. The date is only valid the first time, so we would like to change the wording to make it less confusing.