### PR TITLE
fix save_destroy on Katello

### DIFF
--- a/app/services/foreman_expire_hosts/safe_destroy.rb
+++ b/app/services/foreman_expire_hosts/safe_destroy.rb
@@ -15,7 +15,7 @@ module ForemanExpireHosts
       # See https://community.theforeman.org/t/how-to-properly-destroy-a-content-host/8621
       # for reasoning.
       if subject.is_a?(Host::Base) && with_katello?
-        Katello::RegistrationManager.unregister_host(host)
+        Katello::RegistrationManager.unregister_host(subject)
       else
         subject.destroy!
       end


### PR DESCRIPTION
Test for save_destroy does only catch this case if run on a Katello instance. Should we expand the test matrix? If yes, how?