### PR TITLE
add cronjob and improve description in gemspec

### DIFF
--- a/extra/foreman_expire_hosts.cron.d
+++ b/extra/foreman_expire_hosts.cron.d
@@ -1,0 +1,8 @@
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+RAILS_ENV=production
+FOREMAN_HOME=/usr/share/foreman
+
+# Send out notifications about expired hosts
+45 7 * * *      foreman    /usr/sbin/foreman-rake expired_hosts:deliver_notifications >>/var/log/foreman/expired_hosts.log 2>&1

--- a/foreman_expire_hosts.gemspec
+++ b/foreman_expire_hosts.gemspec
@@ -10,7 +10,10 @@ Gem::Specification.new do |s|
   s.authors     = ['Nagarjuna Rachaneni', 'Timo Goebel']
   s.email       = ['nn.nagarjuna@gmail.com', 'mail@timogoebel.name']
   s.summary     = 'Foreman plugin for limiting host lifetime'
-  s.description = 'This Plugin will add new column expired_on to hosts to limit the lifetime of a host.'
+  s.description = <<-DESC
+A Foreman plugin that allows hosts to expire at a configurable date.
+Hosts will be shut down and automatically deleted after a grace period.
+DESC
   s.homepage    = 'https://github.com/theforeman/foreman_expire_hosts'
   s.licenses    = ['GPL-3.0']
 


### PR DESCRIPTION
Having the cronjob in the gem will allow to drop it as separate file from packaging and the description will restore the better one from packaging.