### PR TITLE
Use explicit paths in gemspec

### DIFF
--- a/foreman_expire_hosts.gemspec
+++ b/foreman_expire_hosts.gemspec
@@ -17,9 +17,8 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/theforeman/foreman_expire_hosts'
   s.licenses    = ['GPL-3.0']
 
-  s.files =            `git ls-files`.split("\n")
-  s.test_files =       `git ls-files test`.split("\n")
-  s.extra_rdoc_files = `git ls-files doc`.split("\n") + Dir['README*', 'LICENSE']
+  s.files       = Dir['{app,config,db,extra,lib,locale}/**/*'] + ['LICENSE', 'Rakefile', 'README.md']
+  s.test_files  = Dir['test/**/*']
 
   s.require_paths = ['lib']
 


### PR DESCRIPTION
This fixes the following error during packaging:
```
Checking for unpackaged file(s): /usr/lib/rpm/check-files /builddir/build/BUILDROOT/tfm-rubygem-foreman_expire_hosts-7.0.2-1.fm2_4.el7.noarch
error: Installed (but unpackaged) file(s) found:
   /opt/theforeman/tfm/root/usr/share/gems/gems/foreman_expire_hosts-7.0.2/.github/workflows/ci.yml
    Installed (but unpackaged) file(s) found:
   /opt/theforeman/tfm/root/usr/share/gems/gems/foreman_expire_hosts-7.0.2/.github/workflows/ci.yml
```