### PR TITLE
Fixes day calculation for grace_period

### DIFF
--- a/app/models/concerns/foreman_expire_hosts/host_ext.rb
+++ b/app/models/concerns/foreman_expire_hosts/host_ext.rb
@@ -55,20 +55,20 @@ module ForemanExpireHosts
     def expiration_grace_period_end_date
       return nil unless expires?
 
-      expired_on.to_date + Setting[:days_to_delete_after_host_expiration].to_i
+      expired_on.to_date + Setting[:days_to_delete_after_host_expiration].to_i.days
     end
 
     def expired_past_grace_period?
       return false unless expires?
 
-      expiration_grace_period_end_date <= Date.today
+      expiration_grace_period_end_date.to_date <= Date.today
     end
 
     def pending_expiration?
       return false unless expires?
       return false if expired?
 
-      expired_on - Setting['notify1_days_before_host_expiry'].to_i <= Date.today
+      expired_on.to_date - Setting['notify1_days_before_host_expiry'].to_i.days <= Date.today
     end
 
     def can_modify_expiry_date?


### PR DESCRIPTION
I'm not sure if this bug existed all the time or if it is caused by Ruby changes.

See the following example:
```ruby
[32] pry(main)> host.expired_on
=> Fri, 10 May 2024 22:00:00.000000000 UTC +00:00

[33] pry(main)> host.expired_on - Setting['notify1_days_before_host_expiry'].to_i
=> Fri, 10 May 2024 21:59:53.000000000 UTC +00:00

[34] pry(main)> host.expired_on - Setting['notify1_days_before_host_expiry'].to_i.days
=> Fri, 03 May 2024 22:00:00.000000000 UTC +00:00
```