### PR TITLE
Integrate with Foreman::Cron framework for centralized task scheduling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,6 @@ jobs:
       matrix:
         foreman:
           - 'develop'
-          - '3.14-stable'
-          - '3.13-stable'
     uses: theforeman/actions/.github/workflows/foreman_plugin.yml@v0
     with:
       plugin: foreman_expire_hosts

--- a/extra/foreman_expire_hosts.cron
+++ b/extra/foreman_expire_hosts.cron
@@ -1,8 +1,0 @@
-SHELL=/bin/sh
-PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-
-RAILS_ENV=production
-FOREMAN_HOME=/usr/share/foreman
-
-# Send out notifications about expired hosts
-45 7 * * *      foreman    /usr/sbin/foreman-rake expired_hosts:deliver_notifications >>/var/log/foreman/expired_hosts.log 2>&1

--- a/lib/foreman_expire_hosts/engine.rb
+++ b/lib/foreman_expire_hosts/engine.rb
@@ -15,8 +15,10 @@ module ForemanExpireHosts
 
     initializer 'foreman_expire_hosts.register_plugin', :before => :finisher_hook do |app|
       app.reloader.to_prepare do
+        require 'foreman/cron'
+
         Foreman::Plugin.register :foreman_expire_hosts do
-          requires_foreman '>= 3.13.0'
+          requires_foreman '>= 3.18.0'
           register_custom_status HostStatus::ExpirationStatus
 
           # strong parameters
@@ -76,6 +78,9 @@ module ForemanExpireHosts
           describe_host do
             multiple_actions_provider :expire_hosts_host_multiple_actions
           end
+
+          # Register recurring task with Foreman::Cron framework
+          Foreman::Cron.register(:daily, 'expired_hosts:deliver_notifications')
         end
       end
     end


### PR DESCRIPTION
Migrate from direct cron execution to the centralized Foreman::Cron registration system